### PR TITLE
Remove usings where not necessary.

### DIFF
--- a/PayPalInvoiceSDK/Invoice/InvoiceService.cs
+++ b/PayPalInvoiceSDK/Invoice/InvoiceService.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Xml;
-using PayPal;
 using PayPal.Authentication;
 using PayPal.Util;
-using PayPal.Manager;
 using PayPal.NVP;
 using PayPal.Invoice.Model;
 
@@ -12,11 +8,6 @@ namespace PayPal.Invoice
 {
 	public partial class InvoiceService : BasePayPalService 
 	{
-
-		/// <summary>
-		/// Service Version
-		/// </summary>
-		private const string ServiceVersion = "1.12.0";
 
 		/// <summary>
 		/// Service Name

--- a/PayPalInvoiceSDK/Invoice/PayPalInvoiceModel.cs
+++ b/PayPalInvoiceSDK/Invoice/PayPalInvoiceModel.cs
@@ -3,15 +3,11 @@
  * AUTO_GENERATED_CODE 
  */
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Web;
-using System.Xml;
-using PayPal.Util;
 
 namespace PayPal.Invoice.Model
 {

--- a/PayPalInvoiceSDK/PayPalInvoiceSDK.csproj
+++ b/PayPalInvoiceSDK/PayPalInvoiceSDK.csproj
@@ -39,11 +39,7 @@
       <HintPath>lib\PayPalCoreSDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Services" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Invoice\InvoiceService.cs" />


### PR DESCRIPTION
Look's like api is deprecated. (Visual studio 2005, .net 2.0, commit frequency)
 If it is true maybe it will be reasonable to add information in *.md file like it was in "https://github.com/paypal/merchant-sdk-dotnet" about deprecation.